### PR TITLE
[FIX/Feature] Consider target environment

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,15 +4,16 @@ const core = require('@actions/core');
 const { dotEnvToObject, filterChangedValues } = require("./src/dotenv");
 const { validateConfig } = require("./src/validation");
 const { getVarsFromVercel, patchVercelVars, pushToVercel } = require("./src/vercel");
-const { envFile } = require('./src/config');
+const { envFile, vercel } = require('./src/config');
 
 
 (async () => {
     try {
         validateConfig();
         const dotenv = dotEnvToObject(envFile);
-        const vercelVars = await getVarsFromVercel();
-        const changedVars = filterChangedValues(dotenv, vercelVars.envs);
+        const { envs } = await getVarsFromVercel();
+        const vercelVarsByTarget = envs.filter(e => e.target.join(',') === vercel.environments.join(','));
+        const changedVars = filterChangedValues(dotenv, vercelVarsByTarget);
 
         if (changedVars.length) {
             const { responses, newVars } = await patchVercelVars(changedVars);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vercel-env-push-action",
-  "version": "1.0.0",
+  "version": "3.0.0",
   "description": "Add multiple environment variables to Vercel from a .env file",
   "main": "index.js",
   "scripts": {

--- a/src/dotenv.js
+++ b/src/dotenv.js
@@ -28,7 +28,7 @@ const filterChangedValues = (dotenv, vercelVars) => {
             return objD;
         }
         else if (objV.value !== objD.value) {
-            objD.id = objV.id
+            objD.id = objV.id;
             return objD;
         };
     });

--- a/src/vercel.js
+++ b/src/vercel.js
@@ -10,7 +10,7 @@ const patchVercelVars = async (vars) => {
     const responses = [];
     const newVars = [];
     for (let i = 0; i < vars.length; i++) {
-        const { id, key, value, ...rest } = vars[i];
+        const { id, key, value, type, target, ...rest } = vars[i];
         if (rest.new) {
             console.log("New variable identified:", vars[i]);
             console.log("Saving it for later...");
@@ -20,7 +20,7 @@ const patchVercelVars = async (vars) => {
             const { data } = await axios
                 .patch(
                     `${api}/v9/projects/${project}/env/${id}?teamId=${teamId}`,
-                    { value },
+                    { key, value, type, target },
                     { headers }
                 )
                 .catch((err) => {


### PR DESCRIPTION
# Description
Currently the action does not consider the target environment when updating variables.
For example, if you want to update same variables only in production the action doesn't allow that.

# Solution
Variables are now filtered to match the chosen environments in action input.

