### PR TITLE
Fix/wrong-targets

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,13 @@ const { envFile, vercel } = require('./src/config');
         validateConfig();
         const dotenv = dotEnvToObject(envFile);
         const { envs } = await getVarsFromVercel();
-        const vercelVarsByTarget = envs.filter(e => e.target.sort().join(',') === vercel.environments.sort().join(','));
+        const vercelVarsByTarget = envs.filter(e => {
+            const vercelTargets = e.target.sort().join(',');
+            const inputTargets = vercel.environments.sort().join(',');
+            if ((vercelTargets === inputTargets) || (vercelTargets.includes(inputTargets))) {
+                return e;
+            }
+        });
         const changedVars = filterChangedValues(dotenv, vercelVarsByTarget);
 
         if (changedVars.length) {

--- a/src/vercel.js
+++ b/src/vercel.js
@@ -10,7 +10,7 @@ const patchVercelVars = async (vars) => {
     const responses = [];
     const newVars = [];
     for (let i = 0; i < vars.length; i++) {
-        const { id, key, value, type, target, ...rest } = vars[i];
+        const { id, key, value, type, ...rest } = vars[i];
         if (rest.new) {
             console.log("New variable identified:", vars[i]);
             console.log("Saving it for later...");
@@ -20,7 +20,7 @@ const patchVercelVars = async (vars) => {
             const { data } = await axios
                 .patch(
                     `${api}/v9/projects/${project}/env/${id}?teamId=${teamId}`,
-                    { key, value, type, target },
+                    { key, value, type, },
                     { headers }
                 )
                 .catch((err) => {


### PR DESCRIPTION
# Description

Targets are messed up when a variable has the same value on different environments.

# Solution

- Vars filtering was improved
    - Now, if the provided target is `preview` and a variable has the same value on `preview` and `development` environments, both targets are updated.
- Target is not considered on patch.
